### PR TITLE
Updated _normalize.scss to use the latest version of normalize.css

### DIFF
--- a/_normalize.scss
+++ b/_normalize.scss
@@ -1,14 +1,17 @@
 // =============================================================================
+// Normalize.scss based on Nicolas Gallagher and Jonathan Neal's
+// normalize.css v2.1.0 | MIT License | git.io/normalize
+// =============================================================================
+
+// =============================================================================
 // Normalize.scss settings
 // =============================================================================
-// So since we're using Sass to compile our Normalize, 
-// We can have some actual settings here, so we don't do more than we have to
 
 
 // Set to false if you want to drop support for IE6 and IE7
 // Notice: setting to false might render some elements
 // slightly differently than when set to true
-$legacy_support_for_ie: true !default; // Used also in Compass
+$legacy_support_for_ie: false; // Used also in Compass
 
 
 // Set the default font family here so you don't have to override it later
@@ -50,16 +53,12 @@ summary {
     display: block;
 }
 
-// Corrects inline-block display not defined in IE6/7/8/9 & FF3
+// Corrects inline-block display not defined in 8/9
 
 audio,
 canvas,
 video {
     display: inline-block;
-    @if $legacy_support_for_ie {
-        *display: inline;
-        *zoom: 1;
-    }
 }
 
 // 1. Prevents modern browsers from displaying 'audio' without controls
@@ -70,8 +69,7 @@ audio:not([controls]) {
     height: 0; // 2
 }
 
-// Addresses styling for 'hidden' attribute not present in IE7/8/9, FF3, S4
-// Known issue: no IE6 support
+// Addresses styling for 'hidden' attribute not present in IE8/9
 
 [hidden] {
     display: none;
@@ -143,37 +141,37 @@ a {
 
 @if $normalize_headings == true {
     h1 {
-        font-size:$h1_font_size;
+        font-size: $h1_font_size;
         margin: $h1_margin;
     }
 
     h2 {
-        font-size:$h2_font_size;
+        font-size: $h2_font_size;
         margin: $h2_margin;
     }
 
     h3 {
-        font-size:$h3_font_size;
+        font-size: $h3_font_size;
         margin: $h3_margin;
     }
 
     h4 {
-        font-size:$h4_font_size;
+        font-size: $h4_font_size;
         margin: $h4_margin;
     }
 
     h5 {
-        font-size:$h5_font_size;
+        font-size: $h5_font_size;
         margin: $h5_margin;
     }
 
     h6 {
-        font-size:$h6_font_size;
+        font-size: $h6_font_size;
         margin: $h6_margin;
     }
 }
 
-// Addresses styling not present in IE7/8/9, S5, Chrome
+// Addresses styling not present in IE 8/9, S5, Chrome
 
 abbr[title] {
     border-bottom: 1px dotted;
@@ -216,9 +214,9 @@ mark {
 // Corrects font family set oddly in IE6, S4/5, Chrome
 // en.wikipedia.org/wiki/User:Davidgothberg/Test59
 
-pre,
 code,
 kbd,
+pre,
 samp {
     font-family: monospace, serif;
     @if $legacy_support_for_ie {
@@ -235,6 +233,12 @@ pre {
     word-wrap: break-word;
 }
 
+// Set consistent quote types.
+
+q {
+    quotes: "\201C" "\201D" "\2018" "\2019";
+}
+
 // 1. Addresses CSS quotes not supported in IE6/7
 // 2. Addresses quote property not supported in S4
 
@@ -246,15 +250,16 @@ pre {
 }
 
 // 2
-
 q:before,
 q:after {
     content: '';
     content: none;
 }
 
+// Address inconsistent and variable font size in all browsers.
+ 
 small {
-    font-size: 75%;
+    font-size: 80%;
 }
 
 // Prevents sub and sup affecting line-height in all browsers
@@ -310,7 +315,6 @@ sub {
 nav {
     ul,
     ol {
-        list-style: none;
         @if $legacy_support_for_ie {
             list-style-image: none;
         }    
@@ -368,31 +372,34 @@ fieldset {
 }
 
 // 1. Corrects color not being inherited in IE6/7/8/9
-// 2. Corrects text not wrapping in FF3 
-// 3. Corrects alignment displayed oddly in IE6/7
+// 2. Remove padding so people aren't caught out if they zero out fieldsets.
+// 3. Corrects text not wrapping in FF3 
+// 4. Corrects alignment displayed oddly in IE6/7
 
 legend {
     border: 0; // 1
-    padding: 0;
-    white-space: normal; // 2
+    padding: 0; // 2
+    white-space: normal; // 3
     @if $legacy_support_for_ie {
-        *margin-left: -7px; // 3
+        *margin-left: -7px; // 4
     }    
 }
 
-// 1. Corrects font size not being inherited in all browsers
-// 2. Addresses margins set differently in IE6/7, FF3+, S5, Chrome
-// 3. Improves appearance and consistency in all browsers
+// 1. Correct font family not being inherited in all browsers.
+// 2. Corrects font size not being inherited in all browsers
+// 3. Addresses margins set differently in IE6/7, FF3+, S5, Chrome
+// 4. Improves appearance and consistency in all browsers
 
 button,
 input,
 select,
 textarea {
-    font-size: 100%; // 1
-    margin: 0; // 2
-    vertical-align: baseline; // 3
+    font-family: inherit; // 1
+    font-size: 100%; // 2
+    margin: 0; // 3
+    vertical-align: baseline; // 4
     @if $legacy_support_for_ie {
-        *vertical-align: middle; // 3
+        *vertical-align: middle; // 4
     }    
 }
 
@@ -400,7 +407,17 @@ textarea {
 
 button,
 input {
-    line-height: normal; // 1
+    line-height: normal;
+}
+
+// Address inconsistent `text-transform` inheritance for `button` and `select`.
+// All other form control elements do not inherit `text-transform` values.
+// Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+.
+// Correct `select` style inheritance in Firefox 4+ and Opera.
+
+button,
+select {
+    text-transform: none;
 }
 
 // 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
@@ -446,16 +463,20 @@ input[type="radio"] {
 
 // 1. Addresses appearance set to searchfield in S5, Chrome
 // 2. Addresses box-sizing set to border-box in S5, Chrome (include -moz to future-proof)
-// 3. Removes inner padding and search cancel button in S5, Chrome on OS X
 
 input[type="search"] {
     -webkit-appearance: textfield; // 1
     -moz-box-sizing: content-box;
     -webkit-box-sizing: content-box; // 2
     box-sizing: content-box;
-    &::-webkit-search-decoration, &::-webkit-search-cancel-button { // 3
-        -webkit-appearance: none;
-    }
+}
+
+// Remove inner padding and search cancel button in Safari 5 and Chrome
+// on OS X.
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
 }
 
 // Removes inner padding and border in FF3+


### PR DESCRIPTION
I kept most of the legacy fixes where applicable as SASS lets us make these optional. These have been dropped from the latest version of normalize.css so whether we want to keep them here or not is definitely a question.
