### PR TITLE
Update to normalize.css 2.1.1

### DIFF
--- a/_normalize.scss
+++ b/_normalize.scss
@@ -1,6 +1,6 @@
 // =============================================================================
 // Normalize.scss based on Nicolas Gallagher and Jonathan Neal's
-// normalize.css v2.1.0 | MIT License | git.io/normalize
+// normalize.css v2.1.1 | MIT License | git.io/normalize
 // =============================================================================
 
 // =============================================================================
@@ -32,6 +32,9 @@ $h3_margin: 1em 0 !default;
 $h4_margin: 1.33em 0 !default;
 $h5_margin: 1.67em 0 !default;
 $h6_margin: 2.33em 0 !default;    
+
+$background: #fff !default;    
+$color: #000 !default;    
 
 // =============================================================================
 // HTML5 display definitions
@@ -92,6 +95,8 @@ html {
     @if $legacy_support_for_ie {
         font-size: 100%; // 1
     }
+		background: $background;
+		color: $color;
     -webkit-text-size-adjust: 100%; // 2
     -ms-text-size-adjust: 100%; // 2
 }


### PR DESCRIPTION
From the normalize.css changelog:

```
== 2.1.1 (April 8, 2013)

Normalize root color and background to counter the effects of system color schemes.
```
